### PR TITLE
feat: LLMウォームアップ機能を追加（Issue #9対応）

### DIFF
--- a/specs/quick/001-009-llm-warmup/plan.md
+++ b/specs/quick/001-009-llm-warmup/plan.md
@@ -1,0 +1,66 @@
+---
+status: completed
+created: 2026-02-22
+branch: quick/001-009-llm-warmup
+issue: "#9"
+---
+
+# 009-llm-warmup
+
+## 概要
+
+`make gen-dict` 実行時、Ollamaモデルの初回ロードでバッチ1が必ずタイムアウトで失敗する問題を修正。ウォームアップリクエストを追加してモデルロード完了を待つ。
+
+## ゴール
+
+- [x] ウォームアップ機能の追加により、バッチ1のタイムアウト失敗を防止
+- [x] モデルロード待ち時間を明示的にログ出力
+
+## スコープ外
+
+- ollama_chat のリトライロジック変更
+- バッチサイズ最適化
+- 他モジュールへの影響
+
+## 前提条件
+
+- 既存の `ollama_chat()` を再利用
+- `generate_readings_batch()` の構造は維持
+
+---
+
+## 実装タスク
+
+### Phase 1: ウォームアップ関数追加
+
+- [x] T001 [src/generate_reading_dict.py] `_warmup_model(model, timeout)` 関数を追加
+  - 最小限のリクエスト（"ping"）を送信
+  - timeout はデフォルト 300秒（モデルロード考慮）
+  - ログ出力: "Warming up model: {model}" → "Model ready"
+
+### Phase 2: 呼び出し統合
+
+- [x] T002 [src/generate_reading_dict.py] `generate_readings_batch()` 先頭で `_warmup_model()` を呼び出し
+  - 最初のバッチ処理前に1回だけ実行
+
+### Phase 3: テスト・確認
+
+- [x] T003 [tests/test_generate_reading_dict.py] ウォームアップ関数のユニットテスト追加
+  - `_warmup_model()` がリクエストを送信することを確認（mock）
+- [ ] T004 動作確認: `make gen-dict` でバッチ1が成功することを確認
+
+---
+
+## リスク
+
+| レベル | 内容 |
+|-------|------|
+| LOW   | ウォームアップで300秒使用するが、モデルがロード済みなら数秒で完了 |
+
+---
+
+## 完了条件
+
+- [x] 全タスク完了
+- [x] テスト通過
+- [ ] `make gen-dict` でバッチ1成功確認（手動確認）


### PR DESCRIPTION
## Summary

- `_warmup_model()` 関数を追加してOllamaモデルロード待ちを実装
- `ollama_chat()` に timeout パラメータを追加（デフォルト120秒、ウォームアップ時300秒）
- `generate_readings_batch()` 先頭でウォームアップを呼び出し
- ユニットテスト6件追加

## 問題 (Issue #9)

`make gen-dict` 実行時、Ollamaへの最初のリクエストでモデルのロードが発生し、バッチ1が必ずタイムアウトで失敗していた。

## 解決策

本番バッチ送信前に最小限のリクエスト（"ping"）を送信し、モデルロード完了を待つウォームアップ機能を追加。

## Test plan

- [x] ユニットテスト29件 PASS（新規6件含む）
- [ ] `make gen-dict` でバッチ1が成功することを手動確認

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)