### PR TITLE
feat: add Kedro-style Rich logging

### DIFF
--- a/conf/logging.yml
+++ b/conf/logging.yml
@@ -1,0 +1,36 @@
+# Kedro-style Rich logging configuration
+# Usage: from src.logging_config import setup_logging; setup_logging()
+
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  simple:
+    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    datefmt: "%Y-%m-%d %H:%M:%S"
+
+handlers:
+  rich:
+    class: rich.logging.RichHandler
+    level: INFO
+    rich_tracebacks: true
+    tracebacks_show_locals: false
+    show_path: true
+    markup: true
+
+  file:
+    class: logging.FileHandler
+    level: DEBUG
+    filename: logs/app.log
+    formatter: simple
+    mode: a
+
+root:
+  level: INFO
+  handlers: [rich]
+
+loggers:
+  src:
+    level: INFO
+    handlers: [rich]
+    propagate: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "fugashi",
     "unidic-lite",
     "scipy",
+    "rich",
 ]
 
 [project.optional-dependencies]
@@ -22,6 +23,7 @@ dev = [
     "pytest-forked",
     "mypy",
     "types-requests",
+    "types-PyYAML",
 ]
 
 [tool.ruff]

--- a/src/generate_reading_dict.py
+++ b/src/generate_reading_dict.py
@@ -17,14 +17,10 @@ import requests
 
 from src.dict_manager import get_dict_path, load_dict, save_dict
 from src.llm_reading_generator import extract_technical_terms
+from src.logging_config import setup_logging
 from src.text_cleaner import split_into_pages
 from src.xml2_parser import parse_book2_xml
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    datefmt="%H:%M:%S",
-)
 logger = logging.getLogger(__name__)
 
 OLLAMA_API_URL = "http://localhost:11434/api/chat"
@@ -144,6 +140,7 @@ JSON出力:"""
 
 
 def main() -> None:
+    setup_logging()
     parser = argparse.ArgumentParser(description="Generate reading dictionary using LLM")
     parser.add_argument("input", help="Input markdown file")
     parser.add_argument("--model", default="gpt-oss:20b", help="Ollama model name")

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,0 +1,106 @@
+"""Kedro-style Rich logging configuration.
+
+Provides centralized logging setup with Rich handler for beautiful console output.
+
+Usage:
+    from src.logging_config import setup_logging
+
+    # In main() or entry point:
+    setup_logging()
+
+    # Then use standard logging:
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.info("Processing file: %s", filename)
+
+Output style:
+    [03/02/26 14:30:00] INFO     Processing file: input.xml       my_module.py:42
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.config
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+def setup_logging(
+    config_path: Path | str | None = None,
+    level: int = logging.INFO,
+) -> None:
+    """Configure Kedro-style Rich logging.
+
+    Args:
+        config_path: Path to logging.yml config file.
+                     If None, uses default conf/logging.yml or fallback.
+        level: Default log level (used in fallback mode).
+    """
+    # Try to find config file
+    if config_path is None:
+        # Default location
+        project_root = Path(__file__).parent.parent
+        config_path = project_root / "conf" / "logging.yml"
+
+    config_path = Path(config_path) if isinstance(config_path, str) else config_path
+
+    if config_path and config_path.exists():
+        _setup_from_yaml(config_path)
+    else:
+        _setup_fallback(level)
+
+
+def _setup_from_yaml(config_path: Path) -> None:
+    """Load logging config from YAML file."""
+    import yaml
+
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    # Ensure logs directory exists if file handler is configured
+    for handler_config in config.get("handlers", {}).values():
+        if "filename" in handler_config:
+            log_file = Path(handler_config["filename"])
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    logging.config.dictConfig(config)
+
+    # Log that we're using the config file
+    logger = logging.getLogger(__name__)
+    logger.info("Using '%s' as logging configuration.", config_path)
+
+
+def _setup_fallback(level: int) -> None:
+    """Fallback Rich logging setup without config file."""
+    from rich.logging import RichHandler
+
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        datefmt="[%m/%d/%y %H:%M:%S]",
+        handlers=[
+            RichHandler(
+                rich_tracebacks=True,
+                tracebacks_show_locals=False,
+                show_path=True,
+                markup=True,
+            )
+        ],
+    )
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a logger with the given name.
+
+    Convenience function to get a properly configured logger.
+
+    Args:
+        name: Logger name (typically __name__).
+
+    Returns:
+        Configured logger instance.
+    """
+    return logging.getLogger(name)

--- a/src/text_cleaner_cli.py
+++ b/src/text_cleaner_cli.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 from src.dict_manager import get_content_hash
+from src.logging_config import setup_logging
 from src.text_cleaner import clean_page_text, init_for_content
 from src.xml2_parser import CHAPTER_MARKER, SECTION_MARKER, parse_book2_xml
 
@@ -69,11 +70,8 @@ def main(args: list[str] | None = None) -> None:
     """
     parsed = parse_args(args)
 
-    # Configure logging
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
+    # Configure Rich logging (Kedro-style)
+    setup_logging()
 
     input_path = Path(parsed.input)
 

--- a/src/xml2_pipeline.py
+++ b/src/xml2_pipeline.py
@@ -23,6 +23,7 @@ from src.chapter_processor import (  # noqa: F401
     sanitize_filename,
 )
 from src.dict_manager import get_content_hash
+from src.logging_config import setup_logging
 from src.process_manager import (  # noqa: F401
     cleanup_pid_file,
     get_pid_file_path,
@@ -40,11 +41,6 @@ from src.voicevox_client import (  # noqa: F401
 )
 from src.xml2_parser import CHAPTER_MARKER, SECTION_MARKER, ContentItem, parse_book2_xml  # noqa: F401
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    datefmt="%H:%M:%S",
-)
 logger = logging.getLogger(__name__)
 
 
@@ -101,6 +97,7 @@ def main(args: list[str] | None = None) -> None:
         FileNotFoundError: If input file does not exist
         xml.etree.ElementTree.ParseError: If XML is malformed
     """
+    setup_logging()
     parsed = parse_args(args)
 
     # Check file existence


### PR DESCRIPTION
## Summary
- Add Rich-powered logging with Kedro-style formatting (timestamps, file:line references, rich tracebacks)
- Create `conf/logging.yml` for YAML-based logging configuration
- Create `src/logging_config.py` as centralized setup module
- Migrate all CLI entry points (`text_cleaner_cli`, `xml2_pipeline`, `generate_reading_dict`)

## Changes
| File | Description |
|------|-------------|
| `conf/logging.yml` | YAML logging config |
| `src/logging_config.py` | Centralized logging setup |
| `pyproject.toml` | Add `rich`, `types-PyYAML` |
| `src/*_cli.py`, `src/*_pipeline.py` | Use `setup_logging()` |

## Output Example
```
[03/02/26 20:17:40] INFO     Processing XML: sample/book2.xml    text_cleaner_cli.py:83
                    INFO     Found 1000 content items            text_cleaner_cli.py:87
                    WARNING  No dictionary found                    dict_manager.py:152
```

## Test plan
- [x] 509 tests passing
- [x] ruff lint
- [x] mypy type check
- [x] CLI manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)