### PR TITLE
feat: OpenJTalk警告回避のためテキスト先頭の句読点・長音記号を除去

### DIFF
--- a/specs/quick/005-41/plan.md
+++ b/specs/quick/005-41/plan.md
@@ -1,0 +1,59 @@
+---
+status: completed
+created: 2026-03-07
+branch: quick/005-41
+---
+
+# OpenJTalk警告回避: テキスト先頭の句読点・長音記号を除去
+
+## 概要
+
+VOICEVOXの内部で使用されるOpenJTalkから、テキストの先頭に句読点や長音記号がある場合に警告が発生する。音声生成自体は正常に動作するが、ログが汚れるため前処理で回避する。
+
+## ゴール
+
+- [x] テキスト先頭の句読点・記号を除去する前処理関数を追加
+- [x] synthesize メソッドで前処理を適用
+- [x] ユニットテストを追加
+
+## スコープ外
+
+- テキスト中間・末尾の記号処理
+- OpenJTalk 本体の修正
+
+## 前提条件
+
+- 既存の `VoicevoxSynthesizer.synthesize` メソッドを修正
+- 正規表現パターン: `^[、。，．,.\\s…ー－]+`
+
+---
+
+## 実装タスク
+
+### Phase 1: 前処理関数の追加
+
+- [x] T001 [src/voicevox_client.py] `clean_text_for_voicevox` 関数を追加（先頭の句読点・記号を除去）
+
+### Phase 2: synthesize メソッドへの適用
+
+- [x] T002 [src/voicevox_client.py] `synthesize` メソッド内で `clean_text_for_voicevox` を呼び出し
+
+### Phase 3: テスト
+
+- [x] T003 [tests/test_voicevox_client.py] `clean_text_for_voicevox` のユニットテストを追加
+
+---
+
+## リスク
+
+| レベル | 内容 |
+|-------|------|
+| LOW   | 正規表現パターンが不足している可能性（追加の記号が必要になる場合がある） |
+
+---
+
+## 完了条件
+
+- [x] 全タスク完了
+- [x] テスト通過
+- [x] コードレビュー完了

--- a/src/voicevox_client.py
+++ b/src/voicevox_client.py
@@ -17,6 +17,7 @@ VOICEVOX Engine の起動は不要。
 """
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -50,6 +51,29 @@ STYLE_ID_TO_VVM: dict[int, str] = {
     12: "9.vvm",  # 白上虎太郎 - ふつう
     13: "15.vvm",  # 青山龍星 - ノーマル
 }
+
+
+_LEADING_PUNCT_PATTERN = re.compile(r"^[、。，．,.\s…ー－]+")
+
+
+def clean_text_for_voicevox(text: str) -> str:
+    """テキスト先頭の句読点・長音記号・記号を除去する.
+
+    OpenJTalk が先頭に句読点・長音記号があると警告を発するため、
+    音声合成前にこれらを除去する前処理関数。
+
+    Args:
+        text: 処理するテキスト
+
+    Returns:
+        先頭の句読点・記号を除去した文字列
+
+    Raises:
+        TypeError: text が文字列でない場合
+    """
+    if not isinstance(text, str):
+        raise TypeError(f"text must be str, got {type(text).__name__}")
+    return _LEADING_PUNCT_PATTERN.sub("", text)
 
 
 @dataclass
@@ -255,6 +279,9 @@ class VoicevoxSynthesizer:
         # モデルが未ロードの場合はロード
         if not self._loaded_models:
             self.load_all_models()
+
+        # テキスト先頭の句読点・記号を除去（OpenJTalk 警告回避）
+        text = clean_text_for_voicevox(text)
 
         # AudioQuery を作成
         audio_query = self._synthesizer.create_audio_query(text, style_id)

--- a/tests/test_voicevox_client.py
+++ b/tests/test_voicevox_client.py
@@ -6,11 +6,16 @@ style_id から対応する VVM ファイルのみをロードする機能のテ
 Phase 3 RED Tests - US2: バージョン警告の解消
 VVM ファイルと VOICEVOX Core のバージョンが一致し、警告が出ないことを確認するテスト。
 
+T003 RED Tests - テキスト前処理
+clean_text_for_voicevox 関数のユニットテスト。
+先頭の句読点・長音記号を除去する前処理関数のテスト。
+
 Target functions:
 - src/voicevox_client.py::STYLE_ID_TO_VVM (dict)
 - src/voicevox_client.py::VoicevoxSynthesizer.get_vvm_path_for_style_id()
 - src/voicevox_client.py::VoicevoxSynthesizer.load_model_for_style_id()
 - src/voicevox_client.py::VoicevoxSynthesizer.load_model() (バージョン警告なし検証)
+- src/voicevox_client.py::clean_text_for_voicevox() (テキスト先頭の句読点・記号除去)
 """
 
 import logging
@@ -429,3 +434,153 @@ class TestNoVersionWarning:
                 result = self.synth.verify_vvm_version(style_id)
                 assert result is True, f"style_id {style_id} ({vvm_file}) のバージョンが不一致"
                 checked_vvms.add(vvm_file)
+
+
+# =============================================================================
+# T003: test_clean_text_for_voicevox
+# clean_text_for_voicevox() のユニットテスト
+# 正規表現パターン: ^[、。，．,.\\s…ー－]+
+# =============================================================================
+
+
+class TestCleanTextForVoicevox:
+    """clean_text_for_voicevox() のテスト.
+
+    OpenJTalk 警告回避のために、テキスト先頭の句読点・長音記号を
+    除去する前処理関数のテスト。
+    """
+
+    def setup_method(self):
+        """テストごとに関数をインポート."""
+        from src.voicevox_client import clean_text_for_voicevox
+
+        self.clean = clean_text_for_voicevox
+
+    # --- ハッピーパス ---
+
+    def test_removes_leading_kuten(self):
+        """先頭の句点（。）を除去する."""
+        assert self.clean("。テスト") == "テスト"
+
+    def test_removes_leading_touten(self):
+        """先頭の読点（、）を除去する."""
+        assert self.clean("、テスト") == "テスト"
+
+    def test_removes_leading_choon(self):
+        """先頭の長音記号（ー）を除去する."""
+        assert self.clean("ーテスト") == "テスト"
+
+    def test_removes_multiple_leading_symbols(self):
+        """先頭の複数の記号を除去する."""
+        assert self.clean("、。ーテスト") == "テスト"
+
+    def test_removes_leading_whitespace(self):
+        """先頭の空白を除去する."""
+        assert self.clean("  テスト") == "テスト"
+
+    def test_no_leading_symbols_unchanged(self):
+        """先頭に記号がない場合は変更しない."""
+        assert self.clean("テスト") == "テスト"
+
+    def test_middle_symbols_preserved(self):
+        """中間の記号は残る."""
+        assert self.clean("テスト。です") == "テスト。です"
+
+    def test_trailing_symbols_preserved(self):
+        """末尾の記号は残る."""
+        assert self.clean("テスト。") == "テスト。"
+
+    def test_removes_leading_fullwidth_comma(self):
+        """先頭の全角カンマ（，）を除去する."""
+        assert self.clean("，テスト") == "テスト"
+
+    def test_removes_leading_fullwidth_period(self):
+        """先頭の全角ピリオド（．）を除去する."""
+        assert self.clean("．テスト") == "テスト"
+
+    def test_removes_leading_halfwidth_comma(self):
+        """先頭の半角カンマ（,）を除去する."""
+        assert self.clean(",テスト") == "テスト"
+
+    def test_removes_leading_halfwidth_period(self):
+        """先頭の半角ピリオド（.）を除去する."""
+        assert self.clean(".テスト") == "テスト"
+
+    def test_removes_leading_ellipsis(self):
+        """先頭の省略記号（…）を除去する."""
+        assert self.clean("…テスト") == "テスト"
+
+    def test_removes_leading_dash(self):
+        """先頭のダッシュ（－）を除去する."""
+        assert self.clean("－テスト") == "テスト"
+
+    def test_removes_mixed_leading_symbols_and_spaces(self):
+        """先頭の記号と空白が混在する場合もすべて除去する."""
+        assert self.clean("。 、ーテスト") == "テスト"
+
+    # --- エッジケース ---
+
+    def test_empty_string_returns_empty(self):
+        """空文字列は空文字列を返す."""
+        assert self.clean("") == ""
+
+    def test_only_symbols_returns_empty(self):
+        """記号のみの文字列は空文字列を返す."""
+        assert self.clean("。、ー") == ""
+
+    def test_only_whitespace_returns_empty(self):
+        """空白のみの文字列は空文字列を返す."""
+        assert self.clean("   ") == ""
+
+    def test_none_raises_type_error(self):
+        """None を渡すと TypeError が発生する."""
+        with pytest.raises(TypeError):
+            self.clean(None)
+
+    def test_non_string_raises_type_error(self):
+        """文字列以外の型を渡すと TypeError が発生する."""
+        with pytest.raises(TypeError):
+            self.clean(123)
+
+    def test_single_character_text_unchanged(self):
+        """1文字テキストは変更しない."""
+        assert self.clean("テ") == "テ"
+
+    def test_single_symbol_removed(self):
+        """記号1文字のみは除去されて空文字列を返す."""
+        assert self.clean("。") == ""
+
+    def test_newline_in_middle_preserved(self):
+        """中間の改行は残る."""
+        result = self.clean("テスト\nです")
+        assert result == "テスト\nです"
+
+    def test_leading_newline_removed(self):
+        """先頭の改行は除去される（\\s にマッチ）."""
+        assert self.clean("\nテスト") == "テスト"
+
+    def test_unicode_text_unchanged(self):
+        """Unicode テキストは変更しない."""
+        assert self.clean("Hello, World!") == "Hello, World!"
+
+    def test_emoji_text_unchanged(self):
+        """絵文字を含むテキストは先頭の記号のみ除去する."""
+        assert self.clean("。テスト😀") == "テスト😀"
+
+    def test_returns_string_type(self):
+        """戻り値は常に文字列型."""
+        result = self.clean("テスト")
+        assert isinstance(result, str)
+
+    def test_long_text_performance(self):
+        """長いテキスト（1000文字以上）を正常に処理する."""
+        long_text = "テスト" * 400  # 1200文字
+        text_with_prefix = "。" + long_text
+        result = self.clean(text_with_prefix)
+        assert result == long_text
+
+    def test_preserves_all_non_leading_content(self):
+        """先頭の記号以外のコンテンツはすべて保持する."""
+        input_text = "。テスト、です。よろしく。"
+        result = self.clean(input_text)
+        assert result == "テスト、です。よろしく。"


### PR DESCRIPTION
## Summary

- VOICEVOXのOpenJTalkから発生する警告を回避するためのテキスト前処理機能を追加
- `clean_text_for_voicevox` 関数で先頭の句読点・長音記号を除去
- `synthesize` メソッド内で自動的に前処理を適用

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `src/voicevox_client.py` | `clean_text_for_voicevox` 関数追加、`synthesize` メソッド修正 |
| `tests/test_voicevox_client.py` | ユニットテスト29件追加 |

## Test plan

- [x] 既存テスト45件がPASS
- [x] 新規テスト29件がPASS
- [x] ruff / mypy チェックPASS
- [ ] 実際のVOICEVOX音声生成で警告が出ないことを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)