### PR TITLE
fix: dialogue パイプラインに読み辞書適用を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ dialogue-split: ## Split long texts in dialogue XML for TTS (MAX_LENGTH=300)
 	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.dialogue_text_splitter -i "$(OUTPUT)/dialogue_book.xml" --max-length $(MAX_LENGTH)
 
 dialogue-tts: ## Generate multi-speaker TTS from dialogue XML (ACCELERATION_MODE=AUTO|CPU|GPU)
-	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.dialogue_pipeline -i "$(OUTPUT)/dialogue_book.xml" -o "$(OUTPUT)" --acceleration-mode "$(ACCELERATION_MODE)"
+	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.dialogue_pipeline -i "$(OUTPUT)/dialogue_book.xml" -o "$(OUTPUT)" --acceleration-mode "$(ACCELERATION_MODE)" --dict-source "$(INPUT)"
 
 dialogue: dialogue-convert dialogue-split gen-dict clean-text dialogue-tts ## Run full dialogue pipeline
 

--- a/src/dialogue_pipeline.py
+++ b/src/dialogue_pipeline.py
@@ -19,12 +19,65 @@ from xml.etree import ElementTree
 import numpy as np
 import soundfile as sf
 
-from src.dict_manager import get_content_hash
+from src.dict_manager import get_content_hash, load_dict
+from src.llm_reading_generator import apply_llm_readings
+from src.number_normalizer import normalize_numbers
+from src.reading_dict import apply_reading_rules
 
 logger = logging.getLogger(__name__)
 
+# Module-level reading dictionary (set via init_readings)
+_READINGS: dict[str, str] = {}
+
 # 日本語文字のUnicode範囲（ひらがな、カタカナ、漢字）
 _JAPANESE_PATTERN = re.compile(r"[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]")
+
+
+def init_readings(dict_source_path: Path | None) -> None:
+    """Initialize reading dictionary from source file.
+
+    Args:
+        dict_source_path: Path to the original XML/MD file for dictionary lookup.
+                         If None, readings dictionary will be empty.
+    """
+    global _READINGS
+    if dict_source_path is not None and dict_source_path.exists():
+        _READINGS = load_dict(dict_source_path)
+        if _READINGS:
+            logger.info("Loaded %d readings from dict for: %s", len(_READINGS), dict_source_path.name)
+        else:
+            logger.warning("No dictionary found for: %s", dict_source_path.name)
+    else:
+        _READINGS = {}
+        if dict_source_path is not None:
+            logger.warning("Dict source file not found: %s", dict_source_path)
+
+
+def apply_readings_to_text(text: str) -> str:
+    """Apply reading rules and dictionary to text for TTS.
+
+    Applies in order:
+    1. Number normalization (123 → ひゃくにじゅうさん)
+    2. Static reading rules (common technical terms)
+    3. LLM-generated readings (per-book dictionary)
+
+    Args:
+        text: Input text to process
+
+    Returns:
+        Text with readings applied
+    """
+    # 1. Normalize numbers (must be first - before reading rules)
+    text = normalize_numbers(text)
+
+    # 2. Apply static reading rules (critical terms like SRE, API, AWS)
+    text = apply_reading_rules(text)
+
+    # 3. Apply LLM-generated readings if available
+    if _READINGS:
+        text = apply_llm_readings(text, _READINGS)
+
+    return text
 
 
 def is_speakable_text(text: str) -> bool:
@@ -211,6 +264,9 @@ def synthesize_utterance(
     if not text:
         raise ValueError("text must not be empty")
 
+    # Apply reading rules and dictionary before TTS
+    processed_text = apply_readings_to_text(text)
+
     # 話者IDからスタイルIDを取得（未知IDはエラー）
     style_id = get_style_id(speaker_id)
 
@@ -219,7 +275,7 @@ def synthesize_utterance(
     if speed_scale is not None:
         kwargs["speed_scale"] = speed_scale
 
-    wav_bytes: bytes = synthesizer.synthesize(text, **kwargs)
+    wav_bytes: bytes = synthesizer.synthesize(processed_text, **kwargs)
 
     # バイト列をnumpy配列に変換
     with io.BytesIO(wav_bytes) as buf:
@@ -503,6 +559,12 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         default="AUTO",
         help="VOICEVOX加速モード（デフォルト: AUTO）",
     )
+    parser.add_argument(
+        "--dict-source",
+        type=str,
+        default=None,
+        help="元のXML/MDファイルパス（読み辞書参照用）",
+    )
 
     return parser.parse_args(args)
 
@@ -523,6 +585,10 @@ def main() -> int:
     if not input_path.exists():
         logger.error("Input file not found: %s", input_path)
         return 1
+
+    # Initialize reading dictionary from source file
+    dict_source_path = Path(args.dict_source) if args.dict_source else None
+    init_readings(dict_source_path)
 
     # Note: カスタムスタイル設定は将来のバージョンで実装予定
     # 現在は DEFAULT_SPEAKERS を使用

--- a/tests/test_dialogue_pipeline.py
+++ b/tests/test_dialogue_pipeline.py
@@ -25,9 +25,11 @@ import pytest
 try:
     from src.dialogue_pipeline import (
         Speaker,
+        apply_readings_to_text,
         concatenate_section_audio,
         get_chapter_number,
         get_style_id,
+        init_readings,
         is_speakable_text,
         parse_args,
         parse_dialogue_xml,
@@ -38,9 +40,11 @@ try:
 except ImportError:
     _MODULE_AVAILABLE = False
     Speaker = None  # type: ignore[assignment,misc]
+    apply_readings_to_text = None  # type: ignore[assignment]
     concatenate_section_audio = None  # type: ignore[assignment]
     get_chapter_number = None  # type: ignore[assignment]
     get_style_id = None  # type: ignore[assignment]
+    init_readings = None  # type: ignore[assignment]
     is_speakable_text = None  # type: ignore[assignment]
     parse_args = None  # type: ignore[assignment]
     parse_dialogue_xml = None  # type: ignore[assignment]
@@ -852,3 +856,77 @@ class TestParseArgs:
         assert args.speed == 0.8
         assert args.voicevox_dir == "/vv"
         assert args.acceleration_mode == "GPU"
+
+    def test_dict_source_default(self) -> None:
+        """--dict-source のデフォルトは None。"""
+        _require_module()
+        args = parse_args(["-i", "dialogue.xml"])
+        assert args.dict_source is None
+
+    def test_dict_source_custom(self) -> None:
+        """--dict-source でカスタムパスを指定できる。"""
+        _require_module()
+        args = parse_args(["-i", "dialogue.xml", "--dict-source", "book.xml"])
+        assert args.dict_source == "book.xml"
+
+
+# ===========================================================================
+# T055: 読み辞書初期化 init_readings() のテスト
+# ===========================================================================
+
+
+class TestInitReadings:
+    """init_readings()の辞書初期化テスト。"""
+
+    def test_init_with_none_path(self) -> None:
+        """Noneパス指定時は空辞書で初期化される。"""
+        _require_module()
+        # Should not raise
+        init_readings(None)
+
+    def test_init_with_nonexistent_path(self) -> None:
+        """存在しないパス指定時は空辞書で初期化される。"""
+        _require_module()
+        # Should not raise
+        init_readings(Path("/nonexistent/file.xml"))
+
+
+# ===========================================================================
+# T056: テキストへの読み適用 apply_readings_to_text() のテスト
+# ===========================================================================
+
+
+class TestApplyReadingsToText:
+    """apply_readings_to_text()のテスト。"""
+
+    def test_number_normalization(self) -> None:
+        """数字が読み仮名に変換される。"""
+        _require_module()
+        # Reset readings to empty
+        init_readings(None)
+        result = apply_readings_to_text("第3章")
+        # Number normalization should convert 3 to reading
+        assert "3" not in result or "さん" in result or "だいさん" in result
+
+    def test_static_reading_rules(self) -> None:
+        """静的な読み辞書のルールが適用される。"""
+        _require_module()
+        init_readings(None)
+        result = apply_readings_to_text("SREの基本")
+        # SRE should be converted (check that original is transformed)
+        assert "SRE" not in result or "エス" in result
+
+    def test_empty_text(self) -> None:
+        """空文字列は空文字列を返す。"""
+        _require_module()
+        init_readings(None)
+        result = apply_readings_to_text("")
+        assert result == ""
+
+    def test_plain_japanese(self) -> None:
+        """平文の日本語はそのまま返される。"""
+        _require_module()
+        init_readings(None)
+        result = apply_readings_to_text("これはテストです")
+        # Plain Japanese should pass through (possibly with punctuation changes)
+        assert "テスト" in result


### PR DESCRIPTION
## Summary

Fixes #53

- `dialogue_pipeline.py` に読み辞書のロードと適用機能を追加
- `--dict-source` オプションで元のXMLファイルを指定可能に
- Makefile の `dialogue-tts` ターゲットを更新

## Changes

- `init_readings()`: 元XMLから読み辞書をロード
- `apply_readings_to_text()`: 数字正規化・静的辞書・LLM辞書を適用
- `synthesize_utterance()` でTTS前にテキストクリーニングを実行

## Test plan

- [x] 新機能のユニットテスト追加 (8テスト)
- [x] 既存テスト全パス (849 passed)
- [x] lint/mypy パス
- [x] coverage 71.52% (閾値70%以上)

🤖 Generated with [Claude Code](https://claude.com/claude-code)