### PR TITLE
feat: dialogue パイプラインにチャプター/セクション効果音を追加

### DIFF
--- a/src/dialogue_pipeline.py
+++ b/src/dialogue_pipeline.py
@@ -19,12 +19,16 @@ from xml.etree import ElementTree
 import numpy as np
 import soundfile as sf
 
+from src.chapter_processor import load_sound
 from src.dict_manager import get_xml_content_hash, load_dict
 from src.llm_reading_generator import apply_llm_readings
 from src.number_normalizer import normalize_numbers
 from src.reading_dict import apply_reading_rules
 
 logger = logging.getLogger(__name__)
+
+# 効果音セグメントの話者ID（実在話者と衝突しない識別子）
+_SOUND_EFFECT_SPEAKER_ID = "__sound_effect__"
 
 # Module-level reading dictionary (set via init_readings)
 _READINGS: dict[str, str] = {}
@@ -447,17 +451,22 @@ def process_dialogue_sections(
     synthesizer: Any,
     output_dir: Path,
     speed_scale: float = 1.0,
+    chapter_sound: np.ndarray | None = None,
+    section_sound: np.ndarray | None = None,
 ) -> list[Path]:
     """対話セクションリストから音声ファイルを生成する統合関数.
 
     各セクションの introduction, utterances, conclusion を合成し、
     チャプター単位でWAVファイルとして保存する。
+    チャプター開始時にチャプター効果音、セクション開始時にセクション効果音を挿入可能。
 
     Args:
         sections: parse_dialogue_xml() が返すセクションリスト
         synthesizer: VoicevoxSynthesizerインスタンス
         output_dir: 音声ファイルの出力ディレクトリ
         speed_scale: 読み上げ速度スケール
+        chapter_sound: チャプター開始時の効果音 (numpy配列, None=なし)
+        section_sound: セクション開始時の効果音 (numpy配列, None=なし)
 
     Returns:
         生成したWAVファイルのパスリスト
@@ -474,6 +483,7 @@ def process_dialogue_sections(
     logger.info("Grouped %d sections into %d chapters", len(sections), len(chapters))
 
     generated: list[Path] = []
+    sample_rate = 24000  # VOICEVOX標準サンプルレート
 
     # チャプター番号順にソートして処理
     for chapter_num in sorted(chapters.keys(), key=lambda x: (int(x) if x.isdigit() else 0, x)):
@@ -486,7 +496,18 @@ def process_dialogue_sections(
 
         # チャプター内の全セクションの音声セグメントを収集
         all_segments: list[tuple[np.ndarray, int, str]] = []
-        for section in chapter_sections:
+
+        # チャプター効果音を挿入
+        if chapter_sound is not None:
+            all_segments.append((chapter_sound, sample_rate, _SOUND_EFFECT_SPEAKER_ID))
+            logger.info("  Inserted chapter sound effect")
+
+        for i, section in enumerate(chapter_sections):
+            # 2番目以降のセクションにセクション効果音を挿入
+            if i > 0 and section_sound is not None:
+                all_segments.append((section_sound, sample_rate, _SOUND_EFFECT_SPEAKER_ID))
+                logger.info("  Inserted section sound effect before section %s", section.get("section_number", ""))
+
             section_segments = _synthesize_section(section, synthesizer, speed_scale)
             all_segments.extend(section_segments)
 
@@ -565,8 +586,40 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="元のXML/MDファイルパス（読み辞書参照用）",
     )
+    parser.add_argument(
+        "--chapter-sound",
+        type=str,
+        default="assets/sounds/chapter.mp3",
+        help="チャプター開始時の効果音ファイル（デフォルト: assets/sounds/chapter.mp3）",
+    )
+    parser.add_argument(
+        "--section-sound",
+        type=str,
+        default="assets/sounds/section.mp3",
+        help="セクション開始時の効果音ファイル（デフォルト: assets/sounds/section.mp3）",
+    )
+    parser.add_argument(
+        "--no-chapter-sound",
+        action="store_true",
+        default=False,
+        help="チャプター効果音を無効化する",
+    )
+    parser.add_argument(
+        "--no-section-sound",
+        action="store_true",
+        default=False,
+        help="セクション効果音を無効化する",
+    )
 
-    return parser.parse_args(args)
+    parsed = parser.parse_args(args)
+
+    # --no-chapter-sound / --no-section-sound が指定された場合はNoneに設定
+    if parsed.no_chapter_sound:
+        parsed.chapter_sound = None
+    if parsed.no_section_sound:
+        parsed.section_sound = None
+
+    return parsed
 
 
 def main() -> int:
@@ -632,6 +685,26 @@ def main() -> int:
         logger.error("Failed to initialize VOICEVOX: %s", e)
         return 2
 
+    # 効果音ファイルの読み込み
+    chapter_sound = None
+    section_sound = None
+
+    if args.chapter_sound:
+        sound_path = Path(args.chapter_sound)
+        if sound_path.exists():
+            chapter_sound = load_sound(sound_path)
+            logger.info("Loaded chapter sound: %s", sound_path)
+        else:
+            logger.warning("Chapter sound file not found: %s", sound_path)
+
+    if args.section_sound:
+        sound_path = Path(args.section_sound)
+        if sound_path.exists():
+            section_sound = load_sound(sound_path)
+            logger.info("Loaded section sound: %s", sound_path)
+        else:
+            logger.warning("Section sound file not found: %s", sound_path)
+
     try:
         # 音声生成
         generated = process_dialogue_sections(
@@ -639,6 +712,8 @@ def main() -> int:
             synthesizer=synthesizer,
             output_dir=output_dir,
             speed_scale=args.speed,
+            chapter_sound=chapter_sound,
+            section_sound=section_sound,
         )
         logger.info("Generated %d audio files in %s", len(generated), output_dir)
     except Exception as e:

--- a/tests/test_dialogue_pipeline.py
+++ b/tests/test_dialogue_pipeline.py
@@ -930,3 +930,178 @@ class TestApplyReadingsToText:
         result = apply_readings_to_text("これはテストです")
         # Plain Japanese should pass through (possibly with punctuation changes)
         assert "テスト" in result
+
+
+# ===========================================================================
+# T057: 効果音挿入テスト (Issue #55)
+# ===========================================================================
+
+
+try:
+    from src.dialogue_pipeline import process_dialogue_sections
+except ImportError:
+    process_dialogue_sections = None  # type: ignore[assignment]
+
+
+SAMPLE_MULTI_CHAPTER_XML = """\
+<dialogue-book>
+  <dialogue-section number="1.1" title="セクション1-1">
+    <introduction speaker="narrator">導入1-1</introduction>
+    <dialogue>
+      <utterance speaker="A">発話A1-1</utterance>
+    </dialogue>
+    <conclusion speaker="narrator">結論1-1</conclusion>
+  </dialogue-section>
+  <dialogue-section number="1.2" title="セクション1-2">
+    <introduction speaker="narrator">導入1-2</introduction>
+    <dialogue>
+      <utterance speaker="A">発話A1-2</utterance>
+    </dialogue>
+    <conclusion speaker="narrator">結論1-2</conclusion>
+  </dialogue-section>
+  <dialogue-section number="2.1" title="セクション2-1">
+    <introduction speaker="narrator">導入2-1</introduction>
+    <dialogue>
+      <utterance speaker="A">発話A2-1</utterance>
+    </dialogue>
+    <conclusion speaker="narrator">結論2-1</conclusion>
+  </dialogue-section>
+</dialogue-book>"""
+
+
+class TestSoundEffectInsertion:
+    """効果音挿入機能のテスト (Issue #55)."""
+
+    def _mock_synthesizer(self) -> MagicMock:
+        """WAVバイト列を返すモックシンセサイザーを生成する。"""
+        mock = MagicMock()
+        sample_rate = 24000
+        samples = np.ones(int(sample_rate * 0.1), dtype=np.float32) * 0.3
+        mock.synthesize.return_value = _create_wav_bytes(samples, sample_rate)
+        return mock
+
+    def _make_sound(self, value: float = 0.5, duration: float = 0.05) -> np.ndarray:
+        """テスト用効果音配列を生成する。"""
+        return np.ones(int(24000 * duration), dtype=np.float32) * value
+
+    def test_chapter_sound_inserted_at_chapter_start(self, tmp_path: Path) -> None:
+        """チャプターの先頭にチャプター効果音が挿入される。"""
+        _require_module()
+        sections = parse_dialogue_xml(SAMPLE_MULTI_CHAPTER_XML)
+        chapter_sound = self._make_sound(0.9)
+
+        generated = process_dialogue_sections(
+            sections=sections,
+            synthesizer=self._mock_synthesizer(),
+            output_dir=tmp_path,
+            chapter_sound=chapter_sound,
+        )
+        # 2チャプター分のファイルが生成される
+        assert len(generated) == 2
+
+    def test_section_sound_inserted_at_non_first_section(self, tmp_path: Path) -> None:
+        """チャプター内の2番目以降のセクションにセクション効果音が挿入される。"""
+        _require_module()
+        sections = parse_dialogue_xml(SAMPLE_MULTI_CHAPTER_XML)
+        section_sound = self._make_sound(0.7)
+
+        generated = process_dialogue_sections(
+            sections=sections,
+            synthesizer=self._mock_synthesizer(),
+            output_dir=tmp_path,
+            section_sound=section_sound,
+        )
+        assert len(generated) == 2
+
+    def test_both_sounds_inserted(self, tmp_path: Path) -> None:
+        """チャプター効果音とセクション効果音が両方挿入される。"""
+        _require_module()
+        sections = parse_dialogue_xml(SAMPLE_MULTI_CHAPTER_XML)
+        chapter_sound = self._make_sound(0.9)
+        section_sound = self._make_sound(0.7)
+
+        generated = process_dialogue_sections(
+            sections=sections,
+            synthesizer=self._mock_synthesizer(),
+            output_dir=tmp_path,
+            chapter_sound=chapter_sound,
+            section_sound=section_sound,
+        )
+        assert len(generated) == 2
+        # 各ファイルが存在し、サイズが0でない
+        for path in generated:
+            assert path.exists()
+            assert path.stat().st_size > 0
+
+    def test_no_sound_backward_compatible(self, tmp_path: Path) -> None:
+        """効果音なしの場合、従来通り動作する（後方互換性）。"""
+        _require_module()
+        sections = parse_dialogue_xml(SAMPLE_MULTI_CHAPTER_XML)
+
+        generated = process_dialogue_sections(
+            sections=sections,
+            synthesizer=self._mock_synthesizer(),
+            output_dir=tmp_path,
+        )
+        assert len(generated) == 2
+
+    def test_parse_args_chapter_sound_default(self) -> None:
+        """--chapter-sound のデフォルトは assets/sounds/chapter.mp3。"""
+        _require_module()
+        args = parse_args(["-i", "dialogue.xml"])
+        assert args.chapter_sound == "assets/sounds/chapter.mp3"
+
+    def test_parse_args_section_sound_default(self) -> None:
+        """--section-sound のデフォルトは assets/sounds/section.mp3。"""
+        _require_module()
+        args = parse_args(["-i", "dialogue.xml"])
+        assert args.section_sound == "assets/sounds/section.mp3"
+
+    def test_parse_args_chapter_sound_custom(self) -> None:
+        """--chapter-sound でカスタムパスを指定できる。"""
+        _require_module()
+        args = parse_args(["-i", "dialogue.xml", "--chapter-sound", "/tmp/ch.mp3"])
+        assert args.chapter_sound == "/tmp/ch.mp3"
+
+    def test_parse_args_section_sound_custom(self) -> None:
+        """--section-sound でカスタムパスを指定できる。"""
+        _require_module()
+        args = parse_args(["-i", "dialogue.xml", "--section-sound", "/tmp/sec.mp3"])
+        assert args.section_sound == "/tmp/sec.mp3"
+
+    def test_parse_args_no_chapter_sound(self) -> None:
+        """--no-chapter-sound でチャプター効果音を無効化できる。"""
+        _require_module()
+        args = parse_args(["-i", "dialogue.xml", "--no-chapter-sound"])
+        assert args.chapter_sound is None
+
+    def test_parse_args_no_section_sound(self) -> None:
+        """--no-section-sound でセクション効果音を無効化できる。"""
+        _require_module()
+        args = parse_args(["-i", "dialogue.xml", "--no-section-sound"])
+        assert args.section_sound is None
+
+    def test_chapter_sound_increases_audio_length(self, tmp_path: Path) -> None:
+        """チャプター効果音挿入により音声ファイルのサイズが増加する。"""
+        _require_module()
+        sections = parse_dialogue_xml(SAMPLE_MULTI_CHAPTER_XML)
+        chapter_sound = self._make_sound(0.9, duration=1.0)
+
+        path_no_sound = tmp_path / "no_sound"
+        path_with_sound = tmp_path / "with_sound"
+
+        process_dialogue_sections(
+            sections,
+            self._mock_synthesizer(),
+            path_no_sound,
+        )
+        process_dialogue_sections(
+            sections,
+            self._mock_synthesizer(),
+            path_with_sound,
+            chapter_sound=chapter_sound,
+        )
+
+        size_no = (path_no_sound / "chapter_001.wav").stat().st_size
+        size_with = (path_with_sound / "chapter_001.wav").stat().st_size
+        assert size_with > size_no


### PR DESCRIPTION
## Summary
- `dialogue_pipeline.py` にチャプター/セクション効果音挿入機能を追加
- `--chapter-sound` / `--section-sound` オプション（デフォルト: `assets/sounds/*.mp3` で自動適用）
- `--no-chapter-sound` / `--no-section-sound` で無効化可能
- 既存の `chapter_processor.load_sound()` を再利用

Closes #55

## Test plan
- [x] 新規テスト11件追加（TestSoundEffectInsertion）
- [x] 既存テスト96件が全てPASS（後方互換性確認）
- [x] ruff lint / mypy 通過
- [ ] 実機で効果音付き音声ファイルを再生確認