### PR TITLE
feat: BOOK_DIR 環境変数による入力パス自動解決

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,11 @@ VOICEVOX_DOWNLOADER := download-linux-x64
 # Load defaults from config.yaml
 CFG = grep '^$(1):' config.yaml | head -1 | sed 's/^[^:]*: *//' | sed 's/^"//;s/"$$//'
 
-INPUT ?= $(shell $(call CFG,input))
+BOOK_DIR ?= $(shell $(call CFG,book_dir))
 OUTPUT ?= $(shell $(call CFG,output))
+
+# Derive input file path from BOOK_DIR
+BOOK_INPUT := $(BOOK_DIR)/book.xml
 STYLE_ID ?= 13
 SPEED ?= 1.0
 ACCELERATION_MODE ?= AUTO
@@ -64,32 +67,32 @@ setup-dev: $(VENV)/bin/activate ## Install dev dependencies + pre-commit hooks
 # === Pipeline (gen-dict → xml-tts) ===
 .PHONY: gen-dict clean-text xml-tts run
 
-gen-dict: ## Generate reading dictionary with LLM (INPUT=file)
-	PYTHONPATH=$(CURDIR) $(PYTHON) src/generate_reading_dict.py "$(INPUT)" --model "$(LLM_MODEL)" --merge
+gen-dict: ## Generate reading dictionary with LLM (BOOK_DIR=dir)
+	PYTHONPATH=$(CURDIR) $(PYTHON) src/generate_reading_dict.py "$(BOOK_INPUT)" --model "$(LLM_MODEL)" --merge
 
-clean-text: ## Generate cleaned_text.txt from XML (INPUT=file)
-	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.text_cleaner_cli -i "$(INPUT)" -o "$(OUTPUT)"
+clean-text: ## Generate cleaned_text.txt from XML (BOOK_DIR=dir)
+	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.text_cleaner_cli -i "$(BOOK_INPUT)" -o "$(OUTPUT)"
 
-xml-tts: ## Run XML to TTS pipeline (INPUT=file)
-	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.xml_pipeline -i "$(INPUT)" -o "$(OUTPUT)" --style-id $(STYLE_ID) --speed $(SPEED)
+xml-tts: ## Run XML to TTS pipeline (BOOK_DIR=dir)
+	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.xml_pipeline -i "$(BOOK_INPUT)" -o "$(OUTPUT)" --style-id $(STYLE_ID) --speed $(SPEED)
 
-run: gen-dict clean-text xml-tts ## Run full pipeline: dict → clean-text → TTS (INPUT=file)
+run: gen-dict clean-text xml-tts ## Run full pipeline: dict → clean-text → TTS (BOOK_DIR=dir)
 
 # === Dialogue Pipeline ===
-# Helper to get content hash from INPUT file
-CONTENT_HASH = $(shell PYTHONPATH=$(CURDIR) $(PYTHON) -c "from src.dict_manager import get_xml_content_hash; from pathlib import Path; print(get_xml_content_hash(Path('$(INPUT)')))" 2>/dev/null)
+# Helper to get content hash from BOOK_INPUT file
+CONTENT_HASH = $(shell PYTHONPATH=$(CURDIR) $(PYTHON) -c "from src.dict_manager import get_xml_content_hash; from pathlib import Path; print(get_xml_content_hash(Path('$(BOOK_INPUT)')))" 2>/dev/null)
 HASH_DIR = $(OUTPUT)/$(CONTENT_HASH)
 
 .PHONY: dialogue-convert dialogue-split dialogue-tts dialogue
 
-dialogue-convert: ## Convert book XML to dialogue form with LLM (INPUT=file)
-	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.dialogue_converter -i "$(INPUT)" -o "$(OUTPUT)" --model "$(LLM_MODEL)"
+dialogue-convert: ## Convert book XML to dialogue form with LLM (BOOK_DIR=dir)
+	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.dialogue_converter -i "$(BOOK_INPUT)" -o "$(OUTPUT)" --model "$(LLM_MODEL)"
 
 dialogue-split: ## Split long texts in dialogue XML for TTS (MAX_LENGTH=300)
 	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.dialogue_text_splitter -i "$(HASH_DIR)/dialogue_book.xml" --max-length $(MAX_LENGTH)
 
 dialogue-tts: ## Generate multi-speaker TTS from dialogue XML (ACCELERATION_MODE=AUTO|CPU|GPU)
-	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.dialogue_pipeline -i "$(HASH_DIR)/dialogue_book.xml" -o "$(OUTPUT)" --acceleration-mode "$(ACCELERATION_MODE)" --dict-source "$(INPUT)"
+	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.dialogue_pipeline -i "$(HASH_DIR)/dialogue_book.xml" -o "$(OUTPUT)" --acceleration-mode "$(ACCELERATION_MODE)" --dict-source "$(BOOK_INPUT)"
 
 dialogue: dialogue-convert dialogue-split gen-dict clean-text dialogue-tts ## Run full dialogue pipeline
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ make setup
 
 ```bash
 # 辞書生成 → テキストクリーニング → TTS を順次実行
-make run INPUT=path/to/book.xml
+make run BOOK_DIR=path/to/book_dir
+
+# ebook-ocr 連携: BOOK_DIR 環境変数を使用（パス指定不要）
+export BOOK_DIR=/home/user/ebook-ocr/output/848d29b0
+make run
 ```
 
 #### 1.2 段階的実行（推奨）
@@ -28,14 +32,14 @@ make run INPUT=path/to/book.xml
 
 ```bash
 # Step 1: 読み辞書生成（固有名詞・専門用語の読み方を LLM で生成）
-make gen-dict INPUT=path/to/book.xml
+make gen-dict BOOK_DIR=path/to/book_dir
 
 # Step 2: テキストクリーニング（URL除去、数字変換等）
 # → data/{hash}/cleaned_text.txt が生成される
-make clean-text INPUT=path/to/book.xml
+make clean-text BOOK_DIR=path/to/book_dir
 
 # Step 3: TTS 音声生成（cleaned_text.txt から音声生成）
-make xml-tts INPUT=path/to/book.xml
+make xml-tts BOOK_DIR=path/to/book_dir
 ```
 
 #### 1.3 TTS パラメータ調整時の時短テクニック
@@ -44,11 +48,11 @@ make xml-tts INPUT=path/to/book.xml
 
 ```bash
 # 初回: 全パイプライン実行
-make run INPUT=sample.xml
+make run BOOK_DIR=sample
 
 # 2回目以降: TTS のみ再実行（テキストクリーニングをスキップ）
-make xml-tts INPUT=sample.xml SPEED=1.5
-make xml-tts INPUT=sample.xml STYLE_ID=3  # ずんだもん
+make xml-tts BOOK_DIR=sample SPEED=1.5
+make xml-tts BOOK_DIR=sample STYLE_ID=3  # ずんだもん
 ```
 
 **処理時間**: テキストクリーニングのスキップにより処理時間が約50%短縮されます。
@@ -56,11 +60,11 @@ make xml-tts INPUT=sample.xml STYLE_ID=3  # ずんだもん
 ### 2. Markdown パイプライン（章分割あり）
 
 ```bash
-# config.yamlのinputを使用
+# config.yamlのbook_dirを使用
 make run
 
-# 入力ファイルを指定
-make run INPUT=path/to/book.md
+# BOOK_DIRを指定
+make run BOOK_DIR=path/to/book_dir
 ```
 
 出力構造:
@@ -101,7 +105,7 @@ make organize DATA_DIR=data/72a2534e9e81
 ### config.yaml
 
 ```yaml
-input: sample/book.md
+book_dir: sample
 output: data
 
 voicevox:
@@ -121,7 +125,7 @@ chapters:
 
 | 変数 | デフォルト | 説明 |
 |-----|-----------|------|
-| `INPUT` | config.yaml | 入力Markdownファイル |
+| `BOOK_DIR` | config.yaml | 入力ディレクトリ（`book.xml` を含む） |
 | `OUTPUT` | data | 出力ベースディレクトリ |
 | `STYLE_ID` | 13 | VOICEVOXスタイルID |
 | `SPEED` | 1.0 | 話速 |
@@ -138,7 +142,7 @@ make setup         # 環境構築
 make run           # 全パイプライン実行（辞書生成 → テキストクリーニング → TTS）
 make gen-dict      # 読み辞書生成のみ
 make clean-text    # テキストクリーニングのみ（XML → cleaned_text.txt）
-make xml-tts       # TTS生成のみ（INPUT指定または既存cleaned_text.txt使用）
+make xml-tts       # TTS生成のみ（BOOK_DIR指定または既存cleaned_text.txt使用）
 
 # その他のパイプライン
 make run-simple    # TTS実行（章分割なし）

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,8 @@
 # Text Reading with LLM - Default Configuration
 # Override per-run values via CLI args or Makefile variables
 
-# Input
-input: sample/book.xml
+# Input (BOOK_DIR contains book.xml)
+book_dir: sample
 
 # Output base directory (actual output will be in data/{content_hash}/)
 output: data


### PR DESCRIPTION
## Summary
- `INPUT` 変数を廃止し、`BOOK_DIR` 環境変数に置換
- `BOOK_DIR/book.xml` を自動解決する `BOOK_INPUT` 内部変数を導入
- `config.yaml` の `input` キーを `book_dir` に変更
- README の使い方を `BOOK_DIR` ベースに更新

## ebook-ocr 連携フロー

```bash
# ebook-ocr 側でパイプライン実行後
export BOOK_DIR=/home/user/ebook-ocr/output/848d29b0

# text-reading-with-llm 側（INPUT 指定不要）
make run
```

## 優先順位

1. `make run BOOK_DIR=path`（明示指定）
2. `BOOK_DIR` 環境変数
3. `config.yaml` の `book_dir` デフォルト値

## Test plan
- [x] 全973テスト通過
- [ ] `make run BOOK_DIR=sample` で動作確認
- [ ] `export BOOK_DIR=sample && make run` で環境変数経由の動作確認

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)