### PR TITLE
feat: ollama_chat() にリクエスト別パラメータ指定機能を追加

### DIFF
--- a/claudedocs/issue-84-llm-config-profiles.md
+++ b/claudedocs/issue-84-llm-config-profiles.md
@@ -1,0 +1,42 @@
+# Issue #84: ollama_chat() にリクエスト別パラメータ指定機能を追加
+
+Parent: #54
+Issue: https://github.com/rengotaku/text-reading-with-llm/issues/84
+
+## 概要
+
+`ollama_chat()` は現在 `temperature=0.3` でハードコードされており、全リクエストで共有されている。
+用途別（読み辞書生成、対話生成、ナレーション等）に最適なパラメータを `config.yaml` から指定できるようにする。
+
+## 設計
+
+### config.yaml 追加セクション
+
+```yaml
+llm:
+  model: gpt-oss:20b
+  api_url: http://localhost:11434/api/chat
+  timeout: 300
+  defaults:
+    temperature: 0.3
+    num_predict: 4096
+  profiles:
+    reading_dict:
+      temperature: 0.2
+    dialogue:
+      temperature: 0.5
+      repeat_penalty: 1.2
+    introduction:
+      temperature: 0.4
+    conclusion:
+      temperature: 0.4
+```
+
+## 実装タスク
+
+- [ ] `config.yaml` に `llm` セクション追加
+- [ ] `src/llm_config.py`（新規）に `load_llm_profile(name)` 追加
+- [ ] `src/generate_reading_dict.py:ollama_chat()` に `options` 引数追加
+- [ ] `src/dialogue_converter.py` の呼び出し側で profile を適用
+- [ ] 既存テストが壊れないこと確認
+- [ ] 対話出力で品質改善確認

--- a/claudedocs/issue-84-llm-config-profiles.md
+++ b/claudedocs/issue-84-llm-config-profiles.md
@@ -34,9 +34,23 @@ llm:
 
 ## 実装タスク
 
-- [ ] `config.yaml` に `llm` セクション追加
-- [ ] `src/llm_config.py`（新規）に `load_llm_profile(name)` 追加
-- [ ] `src/generate_reading_dict.py:ollama_chat()` に `options` 引数追加
-- [ ] `src/dialogue_converter.py` の呼び出し側で profile を適用
-- [ ] 既存テストが壊れないこと確認
-- [ ] 対話出力で品質改善確認
+- [x] `config.yaml` に `llm` セクション追加
+- [x] `src/llm_config.py`（新規）に `load_llm_profile(name)` 追加
+- [x] `src/generate_reading_dict.py:ollama_chat()` に `options` 引数追加
+- [x] `src/dialogue_converter.py` の呼び出し側で profile を適用
+- [x] 既存テストが壊れないこと確認（998 件パス）
+- [ ] 対話出力で品質改善確認（手動検証）
+
+## 実装メモ
+
+- `load_llm_profile(name)` は `llm.defaults` に `llm.profiles.<name>` を上書きマージ
+  した dict を返す。未設定時は空 dict。
+- `generate_reading_dict.ollama_chat()` の `options` 引数は `None` 時に従来の
+  デフォルト（temperature=0.3, num_predict=4096）を維持（後方互換）。
+- `dialogue_converter.convert_section()` 内で `_wrap_with_profile()` により
+  `ollama.chat` を profile ごとにラップ:
+  - `generate_introduction` → `introduction` profile
+  - `generate_conclusion` → `conclusion` profile
+  - `generate_dialogue` → `dialogue` profile
+- profile が未設定の場合は wrapper を挟まず元関数を返すため、既存モックテストの
+  呼び出しシグネチャは変化しない。

--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,29 @@ speakers:
 max_chunk_chars: 500
 
 # ===========================================
+# LLM Settings (Ollama)
+# ===========================================
+# 用途別（profile）に ollama の生成パラメータを指定する。
+# defaults に profile の値を上書きマージして利用する。
+llm:
+  defaults:
+    temperature: 0.3
+    num_predict: 4096
+  profiles:
+    # 読み辞書生成: 正確性重視で低温度
+    reading_dict:
+      temperature: 0.2
+    # 対話生成: 多様性を上げつつ繰り返しを抑制
+    dialogue:
+      temperature: 0.5
+      repeat_penalty: 1.2
+    # 導入/結論ナレーション: 少し温度を上げて自然な表現に
+    introduction:
+      temperature: 0.4
+    conclusion:
+      temperature: 0.4
+
+# ===========================================
 # Chapter Settings
 # ===========================================
 # Enable chapter-based processing (generates separate audio per chapter)

--- a/src/dialogue_converter.py
+++ b/src/dialogue_converter.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Literal
 import yaml
 
 from src.dict_manager import get_xml_content_hash
+from src.llm_config import load_llm_profile
 from src.prompt_loader import load_prompt
 from src.xml_parser import ContentItem, parse_book2_xml
 
@@ -705,6 +706,38 @@ def split_by_heading(section: Section) -> list[Section]:
     return result
 
 
+def _wrap_with_profile(
+    base_func: Callable[..., Any] | None,
+    profile_name: str,
+) -> Callable[..., Any] | None:
+    """ollama.chat を呼び出す関数に profile の options を注入した wrapper を返す。
+
+    config.yaml の `llm.profiles.<profile_name>` を読み込み、ollama.chat の
+    ``options=`` 引数として渡す。profile が空（未設定）の場合は wrapper を
+    挟まず元の関数をそのまま返す（既存テストのモック呼び出しを壊さないため）。
+
+    Args:
+        base_func: ラップ対象の ollama_chat 関数（None の場合は None を返す）
+        profile_name: 読み込む profile 名（"dialogue", "introduction" 等）
+
+    Returns:
+        options を注入する wrapper、または元の関数（profile 未設定時）
+    """
+    if base_func is None:
+        return None
+
+    options = load_llm_profile(profile_name)
+    if not options:
+        return base_func
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        # 呼び出し側が既に options を指定している場合はそちらを優先
+        kwargs.setdefault("options", options)
+        return base_func(*args, **kwargs)
+
+    return wrapped
+
+
 def convert_section(
     section: Section,
     model: str = DEFAULT_MODEL,
@@ -739,25 +772,30 @@ def convert_section(
         # 原文テキストを結合
         original_text = "\n".join(target_section.paragraphs)
 
+        # profile ごとの options を ollama_chat_func に注入する wrapper を作成
+        intro_func = _wrap_with_profile(ollama_chat_func, "introduction")
+        conclusion_func = _wrap_with_profile(ollama_chat_func, "conclusion")
+        dialogue_func = _wrap_with_profile(ollama_chat_func, "dialogue")
+
         # 導入ナレーション生成
         introduction_text = generate_introduction(
             original_text=original_text,
             model=model,
-            ollama_chat_func=ollama_chat_func,
+            ollama_chat_func=intro_func,
         )
 
         # 結論ナレーション生成
         conclusion_text = generate_conclusion(
             original_text=original_text,
             model=model,
-            ollama_chat_func=ollama_chat_func,
+            ollama_chat_func=conclusion_func,
         )
 
         # 対話生成（intro/conclusionをコンテキストとして渡す）
         utterances = generate_dialogue(
             dialogue_paragraphs=target_section.paragraphs,
             model=model,
-            ollama_chat_func=ollama_chat_func,
+            ollama_chat_func=dialogue_func,
             introduction=introduction_text,
             conclusion=conclusion_text,
             speakers=speakers,

--- a/src/generate_reading_dict.py
+++ b/src/generate_reading_dict.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import requests
 
 from src.dict_manager import get_dict_path, load_dict, save_dict
+from src.llm_config import load_llm_profile
 from src.llm_reading_generator import extract_technical_terms
 from src.logging_config import setup_logging
 from src.text_cleaner import split_into_pages
@@ -28,16 +29,32 @@ logger = logging.getLogger(__name__)
 OLLAMA_API_URL = "http://localhost:11434/api/chat"
 
 
-def ollama_chat(model: str, messages: list[dict], max_retries: int = 3, timeout: int = 300) -> dict:
-    """Call Ollama chat API."""
+def ollama_chat(
+    model: str,
+    messages: list[dict],
+    max_retries: int = 3,
+    timeout: int = 300,
+    options: dict | None = None,
+) -> dict:
+    """Call Ollama chat API.
+
+    Args:
+        model: Ollama model name.
+        messages: Chat messages list.
+        max_retries: Retry count for transient failures.
+        timeout: Request timeout seconds.
+        options: Ollama options dict (temperature, num_predict, repeat_penalty, etc.).
+            When None, defaults to ``{"temperature": 0.3, "num_predict": 4096}``.
+            Callers can pass profile-specific options via ``load_llm_profile()``.
+    """
+    if options is None:
+        options = {"temperature": 0.3, "num_predict": 4096}
+
     payload = {
         "model": model,
         "messages": messages,
         "stream": False,
-        "options": {
-            "temperature": 0.3,  # Low temperature for consistent output
-            "num_predict": 4096,
-        },
+        "options": options,
     }
 
     # Calculate request size
@@ -209,6 +226,9 @@ def generate_readings_batch(
     """
     all_readings = {}
 
+    # Load profile-specific LLM options (falls back to defaults if not configured)
+    options = load_llm_profile("reading_dict") or None
+
     # Warm up model before processing first batch
     _warmup_model(model)
 
@@ -260,7 +280,7 @@ def generate_readings_batch(
 
         for attempt in range(max_retries):
             try:
-                response = ollama_chat(model, messages)
+                response = ollama_chat(model, messages, options=options)
                 response_text = response.get("message", {}).get("content", "")
 
                 batch_readings, table_found = _extract_markdown_table(response_text)

--- a/src/llm_config.py
+++ b/src/llm_config.py
@@ -1,0 +1,67 @@
+"""LLM プロファイル設定ローダー。
+
+config.yaml の `llm` セクションから用途別（profile）パラメータを読み込み、
+defaults + profile のマージ結果を返す。
+
+config.yaml の想定構造:
+
+    llm:
+      defaults:
+        temperature: 0.3
+        num_predict: 4096
+      profiles:
+        reading_dict:
+          temperature: 0.2
+        dialogue:
+          temperature: 0.5
+          repeat_penalty: 1.2
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = Path("config.yaml")
+
+
+def load_llm_profile(
+    name: str,
+    config_path: Path | None = None,
+) -> dict[str, Any]:
+    """指定された profile 名の LLM options を返す。
+
+    `llm.defaults` に `llm.profiles.<name>` を上書きマージした dict を返す。
+    config が存在しない、または `llm` セクションがない場合は空 dict を返す。
+    指定された profile 名が存在しない場合は defaults のみを返す。
+
+    Args:
+        name: profile 名（例: "reading_dict", "dialogue", "introduction"）
+        config_path: 設定ファイルパス（None の場合は `config.yaml`）
+
+    Returns:
+        マージ済みの options 辞書（例: {"temperature": 0.5, "num_predict": 4096, "repeat_penalty": 1.2}）
+    """
+    path = config_path or DEFAULT_CONFIG_PATH
+    if not path.exists():
+        return {}
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+    except Exception as e:
+        logger.warning("LLM 設定の読み込みに失敗: %s", e)
+        return {}
+
+    llm_config = config.get("llm") or {}
+    defaults = llm_config.get("defaults") or {}
+    profiles = llm_config.get("profiles") or {}
+    profile = profiles.get(name) or {}
+
+    merged: dict[str, Any] = {**defaults, **profile}
+    return merged

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -1,0 +1,102 @@
+"""src.llm_config.load_llm_profile() のユニットテスト。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.llm_config import load_llm_profile
+
+
+@pytest.fixture
+def config_file(tmp_path: Path) -> Path:
+    """標準的な llm セクション付きの config.yaml を返す。"""
+    content = """
+llm:
+  defaults:
+    temperature: 0.3
+    num_predict: 4096
+  profiles:
+    reading_dict:
+      temperature: 0.2
+    dialogue:
+      temperature: 0.5
+      repeat_penalty: 1.2
+    introduction:
+      temperature: 0.4
+"""
+    path = tmp_path / "config.yaml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_returns_merged_defaults_and_profile(config_file: Path) -> None:
+    """defaults に profile を上書きマージした dict を返す。"""
+    result = load_llm_profile("dialogue", config_path=config_file)
+    assert result == {
+        "temperature": 0.5,  # profile override
+        "num_predict": 4096,  # from defaults
+        "repeat_penalty": 1.2,  # profile only
+    }
+
+
+def test_profile_overrides_single_key(config_file: Path) -> None:
+    """profile が temperature だけ持つ場合も正しくマージ。"""
+    result = load_llm_profile("reading_dict", config_path=config_file)
+    assert result == {"temperature": 0.2, "num_predict": 4096}
+
+
+def test_unknown_profile_returns_defaults_only(config_file: Path) -> None:
+    """未定義 profile 名は defaults のみ返す。"""
+    result = load_llm_profile("nonexistent", config_path=config_file)
+    assert result == {"temperature": 0.3, "num_predict": 4096}
+
+
+def test_missing_config_file_returns_empty(tmp_path: Path) -> None:
+    """config ファイルが存在しない場合は空 dict を返す。"""
+    missing = tmp_path / "no_such.yaml"
+    assert load_llm_profile("dialogue", config_path=missing) == {}
+
+
+def test_config_without_llm_section_returns_empty(tmp_path: Path) -> None:
+    """llm セクションが無い場合は空 dict を返す。"""
+    path = tmp_path / "config.yaml"
+    path.write_text("speakers:\n  SPEAKER_A:\n    name: 教授\n", encoding="utf-8")
+    assert load_llm_profile("dialogue", config_path=path) == {}
+
+
+def test_config_without_defaults(tmp_path: Path) -> None:
+    """defaults 無しで profile のみ定義されている場合も動作する。"""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "llm:\n  profiles:\n    dialogue:\n      temperature: 0.7\n",
+        encoding="utf-8",
+    )
+    result = load_llm_profile("dialogue", config_path=path)
+    assert result == {"temperature": 0.7}
+
+
+def test_config_without_profiles(tmp_path: Path) -> None:
+    """profiles 無しで defaults のみの場合、defaults を返す。"""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "llm:\n  defaults:\n    temperature: 0.3\n",
+        encoding="utf-8",
+    )
+    result = load_llm_profile("dialogue", config_path=path)
+    assert result == {"temperature": 0.3}
+
+
+def test_empty_config_file_returns_empty(tmp_path: Path) -> None:
+    """空ファイルの場合は空 dict を返す。"""
+    path = tmp_path / "config.yaml"
+    path.write_text("", encoding="utf-8")
+    assert load_llm_profile("dialogue", config_path=path) == {}
+
+
+def test_malformed_yaml_returns_empty(tmp_path: Path) -> None:
+    """YAML パースエラー時は空 dict を返す（warning ログ出力）。"""
+    path = tmp_path / "config.yaml"
+    path.write_text("llm:\n  defaults:\n    temperature: [invalid\n", encoding="utf-8")
+    assert load_llm_profile("dialogue", config_path=path) == {}


### PR DESCRIPTION
Closes #84

## 概要

`ollama_chat()` のパラメータ（temperature 等）を用途別に `config.yaml` から指定できるようにする。

## 背景

現状 `src/generate_reading_dict.py:ollama_chat()` は `temperature=0.3` でハードコードされており、全リクエストで共有されている。対話生成も低温度で実行されるため多様性が出にくい。

PR #83 の実験で、用途別に最適なパラメータが異なることが判明:
- 読み辞書生成: `temperature=0.2`（正確性重視）
- 対話生成: `temperature=0.5, repeat_penalty=1.2`（多様性+繰り返し抑制）

## 設計

### config.yaml 追加セクション

\`\`\`yaml
llm:
  model: gpt-oss:20b
  api_url: http://localhost:11434/api/chat
  timeout: 300
  defaults:
    temperature: 0.3
    num_predict: 4096
  profiles:
    reading_dict:
      temperature: 0.2
    dialogue:
      temperature: 0.5
      repeat_penalty: 1.2
    introduction:
      temperature: 0.4
    conclusion:
      temperature: 0.4
\`\`\`

## 実装タスク

- [ ] \`config.yaml\` に \`llm\` セクション追加
- [ ] \`src/llm_config.py\`（新規）に \`load_llm_profile(name)\` 追加
- [ ] \`src/generate_reading_dict.py:ollama_chat()\` に \`options\` 引数追加
- [ ] \`src/dialogue_converter.py\` の呼び出し側で profile を適用
- [ ] 既存テストが壊れないこと確認
- [ ] 対話出力で品質改善確認

## 関連

- Parent issue: #54
- 親コンテキスト: #82 #83
- パラメータ実験: https://github.com/rengotaku/text-reading-with-llm/pull/83#issuecomment-4186650098

## Test plan

- [ ] ユニットテスト: \`load_llm_profile()\` が defaults + profile のマージを正しく行う
- [ ] 既存テスト全パス
- [ ] \`make dialogue-convert\` で対話生成が成功
- [ ] 生成された対話の品質が改善（Q&Aパターン緩和等）