### PR TITLE
fix: WAV出力を PCM_16 に統一しファイルサイズを 1/4 に削減

### DIFF
--- a/src/dialogue_pipeline.py
+++ b/src/dialogue_pipeline.py
@@ -347,7 +347,7 @@ def concatenate_section_audio(
     if output_path is not None:
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        sf.write(str(output_path), combined, sample_rate)
+        sf.write(str(output_path), combined, sample_rate, subtype="PCM_16")
         logger.info("Saved combined audio: %s", output_path)
 
     return combined, sample_rate

--- a/src/voicevox_client.py
+++ b/src/voicevox_client.py
@@ -377,7 +377,7 @@ def save_audio(waveform: np.ndarray, sample_rate: int, output_path: Path) -> Non
         output_path: 出力パス
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    sf.write(str(output_path), waveform, sample_rate)
+    sf.write(str(output_path), waveform, sample_rate, subtype="PCM_16")
     logger.info("Saved: %s", output_path)
 
 
@@ -419,7 +419,7 @@ def concatenate_audio_files(
 
     combined = np.concatenate(all_audio)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    sf.write(str(output_path), combined, sample_rate)
+    sf.write(str(output_path), combined, sample_rate, subtype="PCM_16")
     logger.info("Saved combined audio: %s", output_path)
 
 


### PR DESCRIPTION
## Summary
- `sf.write()` に `subtype='PCM_16'` を追加し、FLOAT_64（8 bytes/sample）→ PCM_16（2 bytes/sample）に統一
- 2時間の chapter WAV で ~2.6GB → ~330MB に削減

## 修正箇所（3箇所）
- `src/voicevox_client.py:380` — `save_audio()`
- `src/voicevox_client.py:422` — `concatenate_audio_files()`
- `src/dialogue_pipeline.py:350` — `concatenate_section_audio()`

## Test plan
- [x] 全 998 テストパス
- [x] ruff / mypy 通過
- [ ] 実際の音声生成で WAV サイズが削減されることを確認

Closes #86