### PR TITLE
fix: chapter_number をデータフロー全体で流通させ chapter_000 肥大化を解消

### DIFF
--- a/src/dialogue_converter.py
+++ b/src/dialogue_converter.py
@@ -116,6 +116,7 @@ class DialogueBlock:
         introduction: 導入テキスト（narrator用）
         dialogue: 対話発言リスト
         conclusion: 結論テキスト（narrator用）
+        chapter_number: 所属するチャプター番号
     """
 
     section_number: str
@@ -123,6 +124,7 @@ class DialogueBlock:
     introduction: str
     dialogue: list[Utterance]
     conclusion: str
+    chapter_number: int | None = None
 
 
 @dataclass
@@ -599,6 +601,8 @@ def to_dialogue_xml(
     root = ET.Element("dialogue-section")
     root.set("number", block.section_number)
     root.set("title", block.section_title)
+    if block.chapter_number is not None:
+        root.set("chapter", str(block.chapter_number))
 
     # introduction要素
     intro_elem = ET.SubElement(root, "introduction")
@@ -807,6 +811,7 @@ def convert_section(
             introduction=introduction_text,
             dialogue=utterances,
             conclusion=conclusion_text,
+            chapter_number=section.chapter_number,
         )
 
         processing_time = time.time() - start_time

--- a/src/dialogue_pipeline.py
+++ b/src/dialogue_pipeline.py
@@ -166,6 +166,7 @@ def parse_dialogue_xml(xml_str_or_path: str) -> list[dict[str, Any]]:
     for dialogue_section in root.iter("dialogue-section"):
         section_number = dialogue_section.get("number", "")
         section_title = dialogue_section.get("title", "")
+        chapter = dialogue_section.get("chapter", "")
 
         # introduction パース
         intro_elem = dialogue_section.find("introduction")
@@ -204,6 +205,7 @@ def parse_dialogue_xml(xml_str_or_path: str) -> list[dict[str, Any]]:
             {
                 "section_number": section_number,
                 "section_title": section_title,
+                "chapter": chapter,
                 "introduction": introduction,
                 "utterances": utterances,
                 "conclusion": conclusion,
@@ -290,20 +292,24 @@ def synthesize_utterance(
     return np.asarray(waveform, dtype=np.float32), int(sample_rate)
 
 
-def get_chapter_number(section_number: str) -> str:
-    """セクション番号からチャプター番号を抽出する.
+def get_chapter_number(section_number: str, chapter: str = "") -> str:
+    """セクション番号またはchapter属性からチャプター番号を抽出する.
 
     Args:
         section_number: セクション番号 (例: "2.1", "2.2", "3")
+        chapter: dialogue XMLのchapter属性値 (例: "1", "2")
 
     Returns:
-        チャプター番号 (例: "2", "3")。ドットがない場合はそのまま返す。
-        空文字列の場合は "0" を返す。
+        チャプター番号 (例: "2", "3")。
+        section_numberが空の場合はchapter属性を使用する。
+        どちらも空の場合は "0" を返す。
     """
-    if not section_number:
-        return "0"
-    # "2.1" -> "2", "3" -> "3"
-    return section_number.split(".")[0]
+    if section_number:
+        # "2.1" -> "2", "3" -> "3"
+        return section_number.split(".")[0]
+    if chapter:
+        return chapter
+    return "0"
 
 
 def concatenate_section_audio(
@@ -479,7 +485,7 @@ def process_dialogue_sections(
     # セクションをチャプター番号でグループ化
     chapters: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for section in sections:
-        chapter_num = get_chapter_number(section["section_number"])
+        chapter_num = get_chapter_number(section["section_number"], section.get("chapter", ""))
         chapters[chapter_num].append(section)
 
     logger.info("Grouped %d sections into %d chapters", len(sections), len(chapters))

--- a/tests/test_dialogue_converter.py
+++ b/tests/test_dialogue_converter.py
@@ -849,6 +849,21 @@ class TestToDialogueXml:
         root = ET.fromstring(result)
         assert root is not None
 
+    def test_to_dialogue_xml_includes_chapter_attribute(self):
+        """chapter_numberがある場合、XMLにchapter属性が含まれる"""
+        block = self._make_block()
+        block.chapter_number = 3
+        result = to_dialogue_xml(block)
+        root = ET.fromstring(result)
+        assert root.get("chapter") == "3"
+
+    def test_to_dialogue_xml_no_chapter_attribute_when_none(self):
+        """chapter_numberがNoneの場合、XMLにchapter属性は含まれない"""
+        block = self._make_block()
+        result = to_dialogue_xml(block)
+        root = ET.fromstring(result)
+        assert root.get("chapter") is None
+
 
 # =============================================================================
 # T016: エッジケース（短文、空セクション）のテスト

--- a/tests/test_dialogue_pipeline.py
+++ b/tests/test_dialogue_pipeline.py
@@ -339,6 +339,34 @@ class TestParseDialogueXml:
         result = parse_dialogue_xml(str(xml_file))
         assert len(result) >= 1
 
+    def test_parse_chapter_attribute(self) -> None:
+        """dialogue-sectionのchapter属性をパースできる。"""
+        _require_module()
+        xml = """\
+<dialogue-book>
+  <dialogue-section number="" title="テスト" chapter="3">
+    <dialogue>
+      <utterance speaker="SPEAKER_A">テスト</utterance>
+    </dialogue>
+  </dialogue-section>
+</dialogue-book>"""
+        result = parse_dialogue_xml(xml)
+        assert result[0]["chapter"] == "3"
+
+    def test_parse_missing_chapter_attribute(self) -> None:
+        """chapter属性がない場合は空文字列になる。"""
+        _require_module()
+        xml = """\
+<dialogue-book>
+  <dialogue-section number="1.1" title="テスト">
+    <dialogue>
+      <utterance speaker="SPEAKER_A">テスト</utterance>
+    </dialogue>
+  </dialogue-section>
+</dialogue-book>"""
+        result = parse_dialogue_xml(xml)
+        assert result[0]["chapter"] == ""
+
 
 # ===========================================================================
 # T051: 話者別スタイルID取得 get_style_id() のテスト
@@ -420,9 +448,24 @@ class TestGetChapterNumber:
         assert get_chapter_number("3") == "3"
 
     def test_empty_string_returns_zero(self) -> None:
-        """空文字列の場合は '0' を返す。"""
+        """空文字列でchapter属性もない場合は '0' を返す。"""
         _require_module()
         assert get_chapter_number("") == "0"
+
+    def test_empty_string_with_chapter_attr(self) -> None:
+        """空文字列でもchapter属性があればそちらを使用する。"""
+        _require_module()
+        assert get_chapter_number("", chapter="3") == "3"
+
+    def test_section_number_takes_priority_over_chapter(self) -> None:
+        """section_numberがある場合はchapter属性より優先する。"""
+        _require_module()
+        assert get_chapter_number("2.1", chapter="5") == "2"
+
+    def test_empty_string_with_empty_chapter(self) -> None:
+        """両方空の場合は '0' を返す。"""
+        _require_module()
+        assert get_chapter_number("", chapter="") == "0"
 
     def test_multiple_dots(self) -> None:
         """複数のドットがある場合は最初の部分のみ返す。"""


### PR DESCRIPTION
## Summary

`section_number` が空のセクション（308中257個、全体の83%）が全て `chapter_000.wav` に集約され 2GB に肥大化していた問題を修正。

### 原因

`DialogueBlock` に `chapter_number` フィールドがなく、`Section` → `DialogueBlock` → dialogue XML の変換で chapter 情報が欠落していた。

```
Section (chapter_number=3) → DialogueBlock (chapter_numberなし)
  → <dialogue-section number="" title="...">  ← chapter情報なし
  → get_chapter_number("") → "0"
  → chapter_000.wav に全部集約
```

### 修正内容

1. `DialogueBlock` に `chapter_number` フィールド追加
2. `to_dialogue_xml()` で `chapter` 属性を出力
3. `parse_dialogue_xml()` で `chapter` 属性を読み取り
4. `get_chapter_number()` で `chapter` 属性を使用

```
修正後: <dialogue-section number="" title="..." chapter="3">
  → get_chapter_number("", chapter="3") → "3"
  → chapter_003.wav に正しく分配
```

### book2.xml の改善効果

| 修正前 | 修正後 |
|--------|--------|
| chapter_000: 257 sections (214,381 chars) | chapter_000: 0 sections |
| chapter_1〜6: 各7〜11 sections | chapter_1〜6: 各36〜68 sections |

## Test plan
- [x] 全 1005 テストパス（+7 新規テスト）
- [x] ruff / mypy 通過
- [ ] `make dialogue BOOK_INPUT=sample/book2.xml` で chapter_000.wav が生成されないことを確認

Closes #86