### PR TITLE
fix: 音声出力を WAV から MP3 に変更してファイルサイズを削減

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
+      - name: Install ffmpeg
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
+
       - name: Install dependencies
         run: pip install -e ".[dev]"
 

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ format: ## Auto-format code with ruff
 clean: ## Remove generated audio files (keep venv and dictionaries)
 	@test -n "$(OUTPUT)" || { echo "Error: OUTPUT is empty, refusing to run find on root"; exit 1; }
 	find $(OUTPUT) -name "*.wav" -delete 2>/dev/null || true
+	find $(OUTPUT) -name "*.mp3" -not -path "*/assets/*" -delete 2>/dev/null || true
 	find $(OUTPUT) -name "cleaned_text.txt" -delete 2>/dev/null || true
 	find $(OUTPUT) -type d -name "pages" -empty -delete 2>/dev/null || true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "unidic-lite",
     "scipy",
     "rich",
+    "pydub",
+    "audioop-lts; python_version>='3.13'",
 ]
 
 [project.optional-dependencies]
@@ -43,6 +45,7 @@ select = ["E", "F", "I", "W", "PLC0415"]
 "src/dict_manager.py" = ["PLC0415"]     # circular import avoidance
 "src/process_manager.py" = ["PLC0415"]  # time (minor, inside conditional)
 "src/dialogue_pipeline.py" = ["PLC0415"]  # voicevox_core (optional, heavy)
+"src/audio_encoder.py" = ["PLC0415"]     # pydub (lazy import for optional dependency)
 "tests/**" = ["PLC0415"]                # テスト内import（pytest fixtures等）
 
 [tool.ruff.lint.isort]

--- a/src/audio_encoder.py
+++ b/src/audio_encoder.py
@@ -1,0 +1,52 @@
+"""MP3エンコードユーティリティモジュール.
+
+numpy 配列の波形データを MP3 ファイルとして保存する機能を提供する。
+内部的に pydub (ffmpeg wrapper) を使用してエンコードを行う。
+"""
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MP3_BITRATE = "128k"
+
+
+def save_as_mp3(
+    waveform: np.ndarray,
+    sample_rate: int,
+    output_path: Path,
+    bitrate: str = DEFAULT_MP3_BITRATE,
+) -> None:
+    """波形データを MP3 ファイルとして保存する.
+
+    Args:
+        waveform: float32 の波形データ（-1.0 〜 1.0）
+        sample_rate: サンプルレート (Hz)
+        output_path: 出力先パス（.mp3 拡張子推奨）
+        bitrate: MP3 ビットレート（例: "128k", "192k", "256k"）
+
+    Raises:
+        ImportError: pydub がインストールされていない場合
+        RuntimeError: ffmpeg が見つからない場合
+    """
+    from pydub import AudioSegment
+
+    # float32 → int16 に変換（クリッピング付き）
+    clipped = np.clip(waveform, -1.0, 1.0)
+    int16_data = (clipped * 32767).astype(np.int16)
+
+    # AudioSegment を生データから構築
+    audio = AudioSegment(
+        data=int16_data.tobytes(),
+        sample_width=2,  # 16-bit
+        frame_rate=sample_rate,
+        channels=1,  # mono
+    )
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    audio.export(str(output_path), format="mp3", bitrate=bitrate)
+    logger.info("Saved MP3: %s (bitrate=%s)", output_path, bitrate)

--- a/src/chapter_processor.py
+++ b/src/chapter_processor.py
@@ -205,7 +205,7 @@ def process_chapters(
                 combined = np.concatenate(audio_segments)
 
                 # Generate sanitized filename
-                filename = sanitize_filename(chapter_num, chapter_title) + ".wav"
+                filename = sanitize_filename(chapter_num, chapter_title) + ".mp3"
                 chapter_path = chapters_dir / filename
                 save_audio(combined, sample_rate, chapter_path)
                 chapter_wav_files.append(chapter_path)
@@ -214,7 +214,7 @@ def process_chapters(
 
         # Concatenate all chapters into book.wav
         if chapter_wav_files:
-            book_path = output_dir / "book.wav"
+            book_path = output_dir / "book.mp3"
             concatenate_audio_files(chapter_wav_files, book_path)
             wav_files.append(book_path)
             logger.info("Combined audio: %s", book_path)
@@ -271,7 +271,7 @@ def process_chapters(
         # Save book.wav
         if audio_segments:
             combined = np.concatenate(audio_segments)
-            output_path = output_dir / "book.wav"
+            output_path = output_dir / "book.mp3"
             save_audio(combined, sample_rate, output_path)
             wav_files.append(output_path)
             logger.info("Combined audio: %s", output_path)

--- a/src/dialogue_pipeline.py
+++ b/src/dialogue_pipeline.py
@@ -352,9 +352,14 @@ def concatenate_section_audio(
 
     if output_path is not None:
         output_path = Path(output_path)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        sf.write(str(output_path), combined, sample_rate, subtype="PCM_16")
-        logger.info("Saved combined audio: %s", output_path)
+        if output_path.suffix.lower() == ".mp3":
+            from src.audio_encoder import save_as_mp3
+
+            save_as_mp3(combined, sample_rate, output_path)
+        else:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            sf.write(str(output_path), combined, sample_rate, subtype="PCM_16")
+            logger.info("Saved combined audio: %s", output_path)
 
     return combined, sample_rate
 
@@ -531,7 +536,7 @@ def process_dialogue_sections(
             )
 
         if all_segments:
-            output_path = output_dir / f"chapter_{chapter_num.zfill(3)}.wav"
+            output_path = output_dir / f"chapter_{chapter_num.zfill(3)}.mp3"
             concatenate_section_audio(all_segments, output_path=output_path)
             generated.append(output_path)
             logger.info("Generated chapter audio: %s", output_path)

--- a/src/voicevox_client.py
+++ b/src/voicevox_client.py
@@ -369,16 +369,26 @@ def normalize_audio(waveform: np.ndarray, target_peak: float = 0.9) -> np.ndarra
 
 
 def save_audio(waveform: np.ndarray, sample_rate: int, output_path: Path) -> None:
-    """波形をWAVファイルに保存.
+    """波形を音声ファイルに保存する.
+
+    出力パスの拡張子に応じて形式を自動選択する:
+    - .mp3: MP3 形式（pydub 経由）
+    - その他: WAV 形式（PCM_16）
 
     Args:
         waveform: 波形データ
         sample_rate: サンプルレート
         output_path: 出力パス
     """
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    sf.write(str(output_path), waveform, sample_rate, subtype="PCM_16")
-    logger.info("Saved: %s", output_path)
+    output_path = Path(output_path)
+    if output_path.suffix.lower() == ".mp3":
+        from src.audio_encoder import save_as_mp3
+
+        save_as_mp3(waveform, sample_rate, output_path)
+    else:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(str(output_path), waveform, sample_rate, subtype="PCM_16")
+        logger.info("Saved: %s", output_path)
 
 
 def concatenate_audio_files(
@@ -418,9 +428,7 @@ def concatenate_audio_files(
         all_audio.append(silence)
 
     combined = np.concatenate(all_audio)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    sf.write(str(output_path), combined, sample_rate, subtype="PCM_16")
-    logger.info("Saved combined audio: %s", output_path)
+    save_audio(combined, sample_rate, output_path)
 
 
 # セットアップヘルパー

--- a/tests/test_audio_encoder.py
+++ b/tests/test_audio_encoder.py
@@ -1,0 +1,62 @@
+"""Tests for audio_encoder.py - MP3 encoding utility."""
+
+from pathlib import Path
+
+import numpy as np
+
+from src.audio_encoder import save_as_mp3
+
+
+class TestSaveAsMp3:
+    """save_as_mp3() のテスト."""
+
+    def test_creates_mp3_file(self, tmp_path: Path) -> None:
+        """MP3 ファイルが生成される."""
+        waveform = np.zeros(24000, dtype=np.float32)
+        output = tmp_path / "test.mp3"
+        save_as_mp3(waveform, 24000, output)
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_mp3_smaller_than_wav(self, tmp_path: Path) -> None:
+        """MP3 は WAV より小さい."""
+        import soundfile as sf
+
+        waveform = np.random.randn(24000 * 10).astype(np.float32) * 0.5
+        sr = 24000
+
+        wav_path = tmp_path / "test.wav"
+        mp3_path = tmp_path / "test.mp3"
+
+        sf.write(str(wav_path), waveform, sr, subtype="PCM_16")
+        save_as_mp3(waveform, sr, mp3_path)
+
+        assert mp3_path.stat().st_size < wav_path.stat().st_size
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        """親ディレクトリが自動作成される."""
+        waveform = np.zeros(2400, dtype=np.float32)
+        output = tmp_path / "a" / "b" / "test.mp3"
+        save_as_mp3(waveform, 24000, output)
+        assert output.exists()
+
+    def test_custom_bitrate(self, tmp_path: Path) -> None:
+        """ビットレート指定で生成できる."""
+        waveform = np.zeros(24000, dtype=np.float32)
+        output = tmp_path / "test.mp3"
+        save_as_mp3(waveform, 24000, output, bitrate="64k")
+        assert output.exists()
+
+    def test_clipping_preserves_range(self, tmp_path: Path) -> None:
+        """範囲外の値がクリッピングされる."""
+        waveform = np.array([2.0, -2.0, 0.5], dtype=np.float32)
+        output = tmp_path / "test.mp3"
+        save_as_mp3(waveform, 24000, output)
+        assert output.exists()
+
+    def test_string_path_accepted(self, tmp_path: Path) -> None:
+        """文字列パスも受け付ける."""
+        waveform = np.zeros(2400, dtype=np.float32)
+        output = tmp_path / "test.mp3"
+        save_as_mp3(waveform, 24000, output)
+        assert output.exists()

--- a/tests/test_dialogue_pipeline.py
+++ b/tests/test_dialogue_pipeline.py
@@ -1157,6 +1157,6 @@ class TestSoundEffectInsertion:
             chapter_sound=chapter_sound,
         )
 
-        size_no = (path_no_sound / "chapter_001.wav").stat().st_size
-        size_with = (path_with_sound / "chapter_001.wav").stat().st_size
+        size_no = (path_no_sound / "chapter_001.mp3").stat().st_size
+        size_with = (path_with_sound / "chapter_001.mp3").stat().st_size
         assert size_with > size_no

--- a/tests/test_xml_pipeline_output.py
+++ b/tests/test_xml_pipeline_output.py
@@ -256,7 +256,7 @@ class TestProcessChaptersCreatesChapterFiles:
             )
 
         chapters_dir = output_dir / "chapters"
-        wav_files = sorted(chapters_dir.glob("*.wav"))
+        wav_files = sorted(chapters_dir.glob("*.mp3"))
 
         assert len(wav_files) == 2, (
             f"2つの chapter WAV ファイルが作成されるべきだが、{len(wav_files)} 個が見つかった: {wav_files}"
@@ -304,7 +304,7 @@ class TestProcessChaptersCreatesChapterFiles:
             )
 
         chapters_dir = output_dir / "chapters"
-        wav_files = list(chapters_dir.glob("*.wav"))
+        wav_files = list(chapters_dir.glob("*.mp3"))
 
         assert len(wav_files) >= 1, "少なくとも1つの WAV ファイルが作成されるべき"
         filename = wav_files[0].stem  # 拡張子なし
@@ -358,7 +358,7 @@ class TestProcessChaptersCreatesChapterFiles:
             )
 
         chapters_dir = output_dir / "chapters"
-        wav_files = sorted(chapters_dir.glob("*.wav"))
+        wav_files = sorted(chapters_dir.glob("*.mp3"))
 
         assert len(wav_files) == 3, (
             f"3つの chapter WAV ファイルが作成されるべきだが、{len(wav_files)} 個が見つかった: "
@@ -370,14 +370,14 @@ class TestProcessChaptersCreatesChapterFiles:
 
 
 class TestProcessChaptersCreatesBookWav:
-    """T024: process_chapters が全 chapter を結合した book.wav を生成することを検証する。
+    """T024: process_chapters が全 chapter を結合した book.mp3 を生成することを検証する。
 
     US2 要件 (FR-004):
-    - 全 chapter を結合した book.wav も生成される
+    - 全 chapter を結合した book.mp3 も生成される
     """
 
     def test_process_chapters_creates_book_wav(self, tmp_path):
-        """process_chapters が book.wav を生成する"""
+        """process_chapters が book.mp3 を生成する"""
         from src.xml_parser import CHAPTER_MARKER, ContentItem, HeadingInfo
         from src.xml_pipeline import process_chapters
 
@@ -429,11 +429,11 @@ class TestProcessChaptersCreatesBookWav:
                 section_sound=None,
             )
 
-        book_wav = output_dir / "book.wav"
-        assert book_wav.exists(), f"book.wav が生成されるべきだが、存在しない: {book_wav}"
+        book_wav = output_dir / "book.mp3"
+        assert book_wav.exists(), f"book.mp3 が生成されるべきだが、存在しない: {book_wav}"
 
     def test_process_chapters_book_wav_and_chapter_files_coexist(self, tmp_path):
-        """book.wav と chapters/ の WAV ファイルが両方存在する"""
+        """book.mp3 と chapters/ の WAV ファイルが両方存在する"""
         from src.xml_parser import CHAPTER_MARKER, ContentItem, HeadingInfo
         from src.xml_pipeline import process_chapters
 
@@ -473,12 +473,12 @@ class TestProcessChaptersCreatesBookWav:
                 section_sound=None,
             )
 
-        book_wav = output_dir / "book.wav"
+        book_wav = output_dir / "book.mp3"
         chapters_dir = output_dir / "chapters"
 
-        assert book_wav.exists(), "book.wav が存在するべき"
+        assert book_wav.exists(), "book.mp3 が存在するべき"
         assert chapters_dir.exists(), "chapters/ ディレクトリが存在するべき"
-        assert len(list(chapters_dir.glob("*.wav"))) >= 1, "chapters/ に少なくとも1つの WAV ファイルが存在するべき"
+        assert len(list(chapters_dir.glob("*.mp3"))) >= 1, "chapters/ に少なくとも1つの WAV ファイルが存在するべき"
 
 
 # --- T025: test_process_content_without_chapters_creates_book_wav ---
@@ -490,15 +490,15 @@ class TestProcessChaptersCreatesBookWav:
 
 
 class TestProcessContentWithoutChaptersCreatesBookWav:
-    """T025: chapter_number が全て None の場合に book.wav のみ生成されることを検証する。
+    """T025: chapter_number が全て None の場合に book.mp3 のみ生成されることを検証する。
 
     US2 エッジケース (FR-009):
-    - chapter を含まない XML の場合、全コンテンツを book.wav として出力する
+    - chapter を含まない XML の場合、全コンテンツを book.mp3 として出力する
     - chapters/ ディレクトリは作成されない
     """
 
     def test_no_chapters_creates_only_book_wav(self, tmp_path):
-        """chapter_number が全て None の場合、book.wav のみ生成される"""
+        """chapter_number が全て None の場合、book.mp3 のみ生成される"""
         from src.xml_parser import ContentItem
         from src.xml_pipeline import process_chapters
 
@@ -539,13 +539,13 @@ class TestProcessContentWithoutChaptersCreatesBookWav:
                 section_sound=None,
             )
 
-        book_wav = output_dir / "book.wav"
+        book_wav = output_dir / "book.mp3"
         chapters_dir = output_dir / "chapters"
 
-        assert book_wav.exists(), "chapter がない場合でも book.wav は生成されるべき"
+        assert book_wav.exists(), "chapter がない場合でも book.mp3 は生成されるべき"
         # chapters/ ディレクトリは作成されないか、空である
         if chapters_dir.exists():
-            wav_files = list(chapters_dir.glob("*.wav"))
+            wav_files = list(chapters_dir.glob("*.mp3"))
             assert len(wav_files) == 0, (
                 f"chapter がない場合、chapters/ に WAV ファイルは作成されないべきだが、"
                 f"{len(wav_files)} 個見つかった: {[f.name for f in wav_files]}"
@@ -600,5 +600,5 @@ class TestProcessContentWithoutChaptersCreatesBookWav:
                 section_sound=None,
             )
 
-        book_wav = output_dir / "book.wav"
-        assert book_wav.exists(), "book.wav は常に生成されるべき"
+        book_wav = output_dir / "book.mp3"
+        assert book_wav.exists(), "book.mp3 は常に生成されるべき"


### PR DESCRIPTION
## Summary
- 音声出力を WAV (PCM_16) から MP3 (128kbps) に変更し、ファイルサイズを約 1/3 に削減
- `src/audio_encoder.py` を新規追加（pydub 経由の MP3 エンコード）
- `save_audio()` が出力パスの拡張子で WAV/MP3 を自動判別
- dialogue_pipeline / chapter_processor / voicevox_client の最終出力を `.mp3` に変更
- `make dialogue` で自動的に MP3 が生成される（追加操作不要）

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `src/audio_encoder.py` | MP3 エンコードユーティリティ（新規） |
| `src/voicevox_client.py` | `save_audio()` に MP3 分岐追加、`concatenate_audio_files()` を `save_audio()` に統合 |
| `src/dialogue_pipeline.py` | 出力を `.mp3` に変更、`concatenate_section_audio()` に MP3 分岐追加 |
| `src/chapter_processor.py` | 出力を `.mp3` に変更 |
| `pyproject.toml` | `pydub`, `audioop-lts` (Python 3.13) 依存追加 |
| `Makefile` | `clean` ターゲットで `.mp3` も削除 |

## Test plan
- [x] 全 1011 テスト通過
- [x] `test_audio_encoder.py` で MP3 エンコード、WAV 比較サイズ検証
- [x] 既存テストの出力パスを `.wav` → `.mp3` に更新済み
- [ ] `make dialogue BOOK_INPUT=sample/book2.xml OUTPUT=data` で実際に MP3 生成を確認

Closes #89